### PR TITLE
Feature/issue 2 historical prices endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 !.idea/runConfigurations
 *.iml
 logs/*
+src/main/java/org.galatea.starter/APIToken.java

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@
 !.idea/runConfigurations
 *.iml
 logs/*
-src/main/java/org.galatea.starter/APIToken.java

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 !.idea/runConfigurations
 *.iml
 logs/*
+src/main/java/org/galatea/starter/APIToken.java

--- a/src/main/java/org/galatea/starter/APIToken.java
+++ b/src/main/java/org/galatea/starter/APIToken.java
@@ -1,4 +1,0 @@
-package org.galatea.starter;
-
-public class APIToken {
-}

--- a/src/main/java/org/galatea/starter/APIToken.java
+++ b/src/main/java/org/galatea/starter/APIToken.java
@@ -1,7 +1,0 @@
-package org.galatea.starter;
-
-public class APIToken {
-
-  public static final String token = "DUMMY_TKN";
-
-}

--- a/src/main/java/org/galatea/starter/APIToken.java
+++ b/src/main/java/org/galatea/starter/APIToken.java
@@ -1,0 +1,4 @@
+package org.galatea.starter;
+
+public class APIToken {
+}

--- a/src/main/java/org/galatea/starter/APIToken.java
+++ b/src/main/java/org/galatea/starter/APIToken.java
@@ -1,0 +1,7 @@
+package org.galatea.starter;
+
+public class APIToken {
+
+  public static final String token = "DUMMY_TKN";
+
+}

--- a/src/main/java/org/galatea/starter/domain/IexHistoricalPrice.java
+++ b/src/main/java/org/galatea/starter/domain/IexHistoricalPrice.java
@@ -1,0 +1,20 @@
+package org.galatea.starter.domain;
+
+import java.math.BigDecimal;
+import java.util.Date;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class IexHistoricalPrice {
+
+  private BigDecimal close;
+  private BigDecimal high;
+  private BigDecimal low;
+  private BigDecimal open;
+  private String symbol;
+  private long volume;
+  private Date date;
+
+}

--- a/src/main/java/org/galatea/starter/domain/IexHistoricalPrice.java
+++ b/src/main/java/org/galatea/starter/domain/IexHistoricalPrice.java
@@ -15,6 +15,6 @@ public class IexHistoricalPrice {
   private BigDecimal open;
   private String symbol;
   private long volume;
-  private Date date;
+  private String date;
 
 }

--- a/src/main/java/org/galatea/starter/domain/IexSymbol.java
+++ b/src/main/java/org/galatea/starter/domain/IexSymbol.java
@@ -10,7 +10,7 @@ public class IexSymbol {
 
   private String symbol;
   private String name;
-  private Date date;
+  private String date;
   private boolean isEnabled;
   private String type;
   private String iexId;

--- a/src/main/java/org/galatea/starter/entrypoint/IexRestController.java
+++ b/src/main/java/org/galatea/starter/entrypoint/IexRestController.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.sf.aspect4log.Log;
 import net.sf.aspect4log.Log.Level;
+import org.galatea.starter.domain.IexHistoricalPrice;
 import org.galatea.starter.domain.IexLastTradedPrice;
 import org.galatea.starter.domain.IexSymbol;
 import org.galatea.starter.service.IexService;
@@ -46,6 +47,21 @@ public class IexRestController {
   public List<IexLastTradedPrice> getLastTradedPrice(
       @RequestParam(value = "symbols") final List<String> symbols) {
     return iexService.getLastTradedPriceForSymbols(symbols);
+  }
+
+  /**
+   * Get historical prices given stock and time range.
+   *
+   * @param symbol stock symbol for historical prices
+   * @param range time range for historical prices (e.g. 3m, 6m, 5y)
+   * @return a list of historical prices for the symbol/range passed in
+   */
+  @GetMapping(value = "${mvc.iex.getHistoricalPricesPath}", produces = {
+      MediaType.APPLICATION_JSON_VALUE})
+  public List<IexHistoricalPrice> getHistoricalPrices(
+      @RequestParam(value = "symbol") final String symbol,
+      @RequestParam(value = "range") final String range) {
+    return iexService.getHistoricalPrices(symbol, range);
   }
 
 }

--- a/src/main/java/org/galatea/starter/entrypoint/IexRestController.java
+++ b/src/main/java/org/galatea/starter/entrypoint/IexRestController.java
@@ -47,8 +47,11 @@ public class IexRestController {
   @GetMapping(value = "${mvc.iex.getLastTradedPricePath}", produces = {
       MediaType.APPLICATION_JSON_VALUE})
   public List<IexLastTradedPrice> getLastTradedPrice(
-      @RequestParam(value = "symbols") final List<String> symbols) {
-    return iexService.getLastTradedPriceForSymbols(symbols);
+      @RequestParam(value = "token", defaultValue = "${mvc.iexToken}") final String token,
+      @RequestParam(value = "symbols") final List<String> symbols
+
+  ) {
+    return iexService.getLastTradedPriceForSymbols(token, symbols);
   }
 
   /**
@@ -61,10 +64,13 @@ public class IexRestController {
   @GetMapping(value = "${mvc.iex.getHistoricalPricesPath}", produces = {
       MediaType.APPLICATION_JSON_VALUE})
   public List<IexHistoricalPrice> getHistoricalPrices(
+      @RequestParam(value = "token", defaultValue = "${mvc.iexToken}") final String token,
       @RequestParam(value = "symbol") final String symbol,
       @RequestParam(value = "range") final String range,
-      @RequestParam(value = "date", required = false) final String date) {
-    return iexService.getHistoricalPrices(symbol, range, date);
+      @RequestParam(value = "date", required = false) final String date
+
+  ) {
+    return iexService.getHistoricalPrices(token, symbol, range, date);
   }
 
 }

--- a/src/main/java/org/galatea/starter/entrypoint/IexRestController.java
+++ b/src/main/java/org/galatea/starter/entrypoint/IexRestController.java
@@ -32,10 +32,8 @@ public class IexRestController {
    * @return a list of all IexStockSymbols.
    */
   @GetMapping(value = "${mvc.iex.getAllSymbolsPath}", produces = {MediaType.APPLICATION_JSON_VALUE})
-  public List<IexSymbol> getAllStockSymbols(
-      @RequestParam(value = "token", defaultValue = "${mvc.iexToken}") final String token
-  ) {
-    return iexService.getAllSymbols(token);
+  public List<IexSymbol> getAllStockSymbols() {
+    return iexService.getAllSymbols();
   }
 
   /**
@@ -47,11 +45,9 @@ public class IexRestController {
   @GetMapping(value = "${mvc.iex.getLastTradedPricePath}", produces = {
       MediaType.APPLICATION_JSON_VALUE})
   public List<IexLastTradedPrice> getLastTradedPrice(
-      @RequestParam(value = "token", defaultValue = "${mvc.iexToken}") final String token,
       @RequestParam(value = "symbols") final List<String> symbols
-
   ) {
-    return iexService.getLastTradedPriceForSymbols(token, symbols);
+    return iexService.getLastTradedPriceForSymbols(symbols);
   }
 
   /**
@@ -64,13 +60,12 @@ public class IexRestController {
   @GetMapping(value = "${mvc.iex.getHistoricalPricesPath}", produces = {
       MediaType.APPLICATION_JSON_VALUE})
   public List<IexHistoricalPrice> getHistoricalPrices(
-      @RequestParam(value = "token", defaultValue = "${mvc.iexToken}") final String token,
       @RequestParam(value = "symbol") final String symbol,
       @RequestParam(value = "range") final String range,
       @RequestParam(value = "date", required = false) final String date
 
   ) {
-    return iexService.getHistoricalPrices(token, symbol, range, date);
+    return iexService.getHistoricalPrices(symbol, range, date);
   }
 
 }

--- a/src/main/java/org/galatea/starter/entrypoint/IexRestController.java
+++ b/src/main/java/org/galatea/starter/entrypoint/IexRestController.java
@@ -55,13 +55,14 @@ public class IexRestController {
    *
    * @param symbol stock symbol for historical prices
    * @param range time range for historical prices (e.g. 3m, 6m, 5y)
+   * @param date date as String; format YYYYMMDD
    * @return a list of historical prices for the symbol/range passed in
    */
   @GetMapping(value = "${mvc.iex.getHistoricalPricesPath}", produces = {
       MediaType.APPLICATION_JSON_VALUE})
   public List<IexHistoricalPrice> getHistoricalPrices(
       @RequestParam(value = "symbol") final String symbol,
-      @RequestParam(value = "range") final String range,
+      @RequestParam(value = "range", required = false) final String range,
       @RequestParam(value = "date", required = false) final String date
 
   ) {

--- a/src/main/java/org/galatea/starter/entrypoint/IexRestController.java
+++ b/src/main/java/org/galatea/starter/entrypoint/IexRestController.java
@@ -32,8 +32,10 @@ public class IexRestController {
    * @return a list of all IexStockSymbols.
    */
   @GetMapping(value = "${mvc.iex.getAllSymbolsPath}", produces = {MediaType.APPLICATION_JSON_VALUE})
-  public List<IexSymbol> getAllStockSymbols() {
-    return iexService.getAllSymbols();
+  public List<IexSymbol> getAllStockSymbols(
+      @RequestParam(value = "token", defaultValue = "${mvc.iexToken}") final String token
+  ) {
+    return iexService.getAllSymbols(token);
   }
 
   /**
@@ -60,8 +62,9 @@ public class IexRestController {
       MediaType.APPLICATION_JSON_VALUE})
   public List<IexHistoricalPrice> getHistoricalPrices(
       @RequestParam(value = "symbol") final String symbol,
-      @RequestParam(value = "range") final String range) {
-    return iexService.getHistoricalPrices(symbol, range);
+      @RequestParam(value = "range") final String range,
+      @RequestParam(value = "date", required = false) final String date) {
+    return iexService.getHistoricalPrices(symbol, range, date);
   }
 
 }

--- a/src/main/java/org/galatea/starter/service/IexClient.java
+++ b/src/main/java/org/galatea/starter/service/IexClient.java
@@ -20,6 +20,7 @@ public interface IexClient {
    * Get a list of all stocks supported by IEX. See https://iextrading.com/developer/docs/#symbols.
    * As of July 2019 this returns almost 9,000 symbols, so maybe don't call it in a loop.
    *
+   * @param token API key from IexService
    * @return a list of all of the stock symbols supported by IEX.
    */
 
@@ -29,6 +30,7 @@ public interface IexClient {
   /**
    * Get the last traded price for each stock symbol passed in. See https://iextrading.com/developer/docs/#last.
    *
+   * @param token API key from IexService
    * @param symbols stock symbols to get last traded price for.
    * @return a list of the last traded price for each of the symbols passed in.
    */
@@ -39,15 +41,12 @@ public interface IexClient {
   /**
    * Get historical prices given stock and time range.
    *
+   * @param token API key from IexService
    * @param symbol stock symbol for historical prices
    * @param range time range for historical prices (e.g. 3m, 6m, 5y)
+   * @param date date as String; format YYYYMMDD
    * @return a list of historical prices for the symbol/range passed in
    */
-  @GetMapping(value = "/stock/{symbol}/chart/{range}")
-  List<IexHistoricalPrice> getHistoricalPrices(@RequestParam("token") String token,
-      @PathVariable("symbol") String symbol,
-      @PathVariable("range") String range);
-
   @GetMapping(value = "/stock/{symbol}/chart/{range}/{date}")
   List<IexHistoricalPrice> getHistoricalPrices(@RequestParam("token") String token,
       @PathVariable("symbol") String symbol,

--- a/src/main/java/org/galatea/starter/service/IexClient.java
+++ b/src/main/java/org/galatea/starter/service/IexClient.java
@@ -22,8 +22,9 @@ public interface IexClient {
    *
    * @return a list of all of the stock symbols supported by IEX.
    */
+
   @GetMapping("/ref-data/symbols")
-  List<IexSymbol> getAllSymbols();
+  List<IexSymbol> getAllSymbols(@RequestParam("token") String token);
 
   /**
    * Get the last traded price for each stock symbol passed in. See https://iextrading.com/developer/docs/#last.
@@ -31,7 +32,7 @@ public interface IexClient {
    * @param symbols stock symbols to get last traded price for.
    * @return a list of the last traded price for each of the symbols passed in.
    */
-  @GetMapping("/tops/last")
+  @GetMapping("/tops/last?token=${mvc.iexToken}")
   List<IexLastTradedPrice> getLastTradedPriceForSymbols(@RequestParam("symbols") String[] symbols);
 
   /**
@@ -41,7 +42,11 @@ public interface IexClient {
    * @param range time range for historical prices (e.g. 3m, 6m, 5y)
    * @return a list of historical prices for the symbol/range passed in
    */
-  @GetMapping(value = "/stock/{symbol}/chart/{range}")
+  @GetMapping(value = "/stock/{symbol}/chart/{range}?token=${mvc.iexToken}")
   List<IexHistoricalPrice> getHistoricalPrices(@PathVariable("symbol") String symbol,
       @PathVariable("range") String range);
+
+  @GetMapping(value = "/stock/{symbol}/chart/{range}/{date}?token=${mvc.iexToken}")
+  List<IexHistoricalPrice> getHistoricalPrices(@PathVariable("symbol") String symbol,
+      @PathVariable("range") String range, @PathVariable("date") String date);
 }

--- a/src/main/java/org/galatea/starter/service/IexClient.java
+++ b/src/main/java/org/galatea/starter/service/IexClient.java
@@ -1,6 +1,7 @@
 package org.galatea.starter.service;
 
 import java.util.List;
+import org.galatea.starter.domain.IexHistoricalPrice;
 import org.galatea.starter.domain.IexLastTradedPrice;
 import org.galatea.starter.domain.IexSymbol;
 import org.springframework.cloud.openfeign.FeignClient;
@@ -31,5 +32,15 @@ public interface IexClient {
    */
   @GetMapping("/tops/last")
   List<IexLastTradedPrice> getLastTradedPriceForSymbols(@RequestParam("symbols") String[] symbols);
+
+  /**
+   * Get historical prices given stock and time range.
+   *
+   * @param symbol stock symbol for historical prices
+   * @param range time range for historical prices (e.g. 3m, 6m, 5y)
+   * @return a list of historical prices for the symbol/range passed in
+   */
+  @GetMapping("/stock")
+  List<IexHistoricalPrice> getHistoricalPrices(@RequestParam("symbol") String symbol, @RequestParam("range") String range);
 
 }

--- a/src/main/java/org/galatea/starter/service/IexClient.java
+++ b/src/main/java/org/galatea/starter/service/IexClient.java
@@ -6,6 +6,7 @@ import org.galatea.starter.domain.IexLastTradedPrice;
 import org.galatea.starter.domain.IexSymbol;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
 /**
@@ -40,7 +41,7 @@ public interface IexClient {
    * @param range time range for historical prices (e.g. 3m, 6m, 5y)
    * @return a list of historical prices for the symbol/range passed in
    */
-  @GetMapping("/stock")
-  List<IexHistoricalPrice> getHistoricalPrices(@RequestParam("symbol") String symbol, @RequestParam("range") String range);
-
+  @GetMapping(value = "/stock/{symbol}/chart/{range}")
+  List<IexHistoricalPrice> getHistoricalPrices(@PathVariable("symbol") String symbol,
+      @PathVariable("range") String range);
 }

--- a/src/main/java/org/galatea/starter/service/IexClient.java
+++ b/src/main/java/org/galatea/starter/service/IexClient.java
@@ -32,8 +32,9 @@ public interface IexClient {
    * @param symbols stock symbols to get last traded price for.
    * @return a list of the last traded price for each of the symbols passed in.
    */
-  @GetMapping("/tops/last?token=${mvc.iexToken}")
-  List<IexLastTradedPrice> getLastTradedPriceForSymbols(@RequestParam("symbols") String[] symbols);
+  @GetMapping("/tops/last")
+  List<IexLastTradedPrice> getLastTradedPriceForSymbols(@RequestParam("token") String token,
+      @RequestParam("symbols") String[] symbols);
 
   /**
    * Get historical prices given stock and time range.
@@ -42,11 +43,14 @@ public interface IexClient {
    * @param range time range for historical prices (e.g. 3m, 6m, 5y)
    * @return a list of historical prices for the symbol/range passed in
    */
-  @GetMapping(value = "/stock/{symbol}/chart/{range}?token=${mvc.iexToken}")
-  List<IexHistoricalPrice> getHistoricalPrices(@PathVariable("symbol") String symbol,
+  @GetMapping(value = "/stock/{symbol}/chart/{range}")
+  List<IexHistoricalPrice> getHistoricalPrices(@RequestParam("token") String token,
+      @PathVariable("symbol") String symbol,
       @PathVariable("range") String range);
 
-  @GetMapping(value = "/stock/{symbol}/chart/{range}/{date}?token=${mvc.iexToken}")
-  List<IexHistoricalPrice> getHistoricalPrices(@PathVariable("symbol") String symbol,
-      @PathVariable("range") String range, @PathVariable("date") String date);
+  @GetMapping(value = "/stock/{symbol}/chart/{range}/{date}")
+  List<IexHistoricalPrice> getHistoricalPrices(@RequestParam("token") String token,
+      @PathVariable("symbol") String symbol,
+      @PathVariable("range") String range,
+      @PathVariable("date") String date);
 }

--- a/src/main/java/org/galatea/starter/service/IexService.java
+++ b/src/main/java/org/galatea/starter/service/IexService.java
@@ -57,5 +57,4 @@ public class IexService {
     return iexClient.getHistoricalPrices(symbol, range);
   }
 
-
 }

--- a/src/main/java/org/galatea/starter/service/IexService.java
+++ b/src/main/java/org/galatea/starter/service/IexService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.galatea.starter.APIToken;
 import org.galatea.starter.domain.IexLastTradedPrice;
 import org.galatea.starter.domain.IexSymbol;
 import org.galatea.starter.domain.IexHistoricalPrice;

--- a/src/main/java/org/galatea/starter/service/IexService.java
+++ b/src/main/java/org/galatea/starter/service/IexService.java
@@ -5,7 +5,6 @@ import java.util.List;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.galatea.starter.APIToken;
 import org.galatea.starter.domain.IexLastTradedPrice;
 import org.galatea.starter.domain.IexSymbol;
 import org.galatea.starter.domain.IexHistoricalPrice;

--- a/src/main/java/org/galatea/starter/service/IexService.java
+++ b/src/main/java/org/galatea/starter/service/IexService.java
@@ -21,14 +21,14 @@ public class IexService {
 
   @NonNull
   private IexClient iexClient;
-
+  private String token = APIToken.token;
 
   /**
    * Get all stock symbols from IEX.
    *
    * @return a list of all Stock Symbols from IEX.
    */
-  public List<IexSymbol> getAllSymbols(final String token) {
+  public List<IexSymbol> getAllSymbols() {
     return iexClient.getAllSymbols(token);
   }
 
@@ -38,9 +38,7 @@ public class IexService {
    * @param symbols the list of symbols to get a last traded price for.
    * @return a list of last traded price objects for each Symbol that is passed in.
    */
-  public List<IexLastTradedPrice> getLastTradedPriceForSymbols(final String token,
-      final List<String> symbols
-      ) {
+  public List<IexLastTradedPrice> getLastTradedPriceForSymbols(final List<String> symbols) {
     if (CollectionUtils.isEmpty(symbols)) {
       return Collections.emptyList();
     } else {
@@ -55,8 +53,8 @@ public class IexService {
    * @param range time range for historical prices (e.g. 3m, 6m, 5y)
    * @return a list of historical prices for the symbol/range passed in
    */
-  public List<IexHistoricalPrice> getHistoricalPrices(final String token, final String symbol,
-      final String range, final String date) {
+  public List<IexHistoricalPrice> getHistoricalPrices(final String symbol, final String range,
+      final String date) {
     if (date == null) { return iexClient.getHistoricalPrices(token, symbol, range); }
     else { return iexClient.getHistoricalPrices(token, symbol, range, date); }
     }

--- a/src/main/java/org/galatea/starter/service/IexService.java
+++ b/src/main/java/org/galatea/starter/service/IexService.java
@@ -28,8 +28,8 @@ public class IexService {
    *
    * @return a list of all Stock Symbols from IEX.
    */
-  public List<IexSymbol> getAllSymbols() {
-    return iexClient.getAllSymbols();
+  public List<IexSymbol> getAllSymbols(final String token) {
+    return iexClient.getAllSymbols(token);
   }
 
   /**
@@ -53,8 +53,10 @@ public class IexService {
    * @param range time range for historical prices (e.g. 3m, 6m, 5y)
    * @return a list of historical prices for the symbol/range passed in
    */
-  public List<IexHistoricalPrice> getHistoricalPrices(final String symbol, final String range) {
-    return iexClient.getHistoricalPrices(symbol, range);
-  }
+  public List<IexHistoricalPrice> getHistoricalPrices(final String symbol, final String range,
+      final String date) {
+    if (date == null) { return iexClient.getHistoricalPrices(symbol, range); }
+    else { return iexClient.getHistoricalPrices(symbol, range, date); }
+    }
 
 }

--- a/src/main/java/org/galatea/starter/service/IexService.java
+++ b/src/main/java/org/galatea/starter/service/IexService.java
@@ -38,11 +38,13 @@ public class IexService {
    * @param symbols the list of symbols to get a last traded price for.
    * @return a list of last traded price objects for each Symbol that is passed in.
    */
-  public List<IexLastTradedPrice> getLastTradedPriceForSymbols(final List<String> symbols) {
+  public List<IexLastTradedPrice> getLastTradedPriceForSymbols(final String token,
+      final List<String> symbols
+      ) {
     if (CollectionUtils.isEmpty(symbols)) {
       return Collections.emptyList();
     } else {
-      return iexClient.getLastTradedPriceForSymbols(symbols.toArray(new String[0]));
+      return iexClient.getLastTradedPriceForSymbols(token, symbols.toArray(new String[0]));
     }
   }
 
@@ -53,10 +55,10 @@ public class IexService {
    * @param range time range for historical prices (e.g. 3m, 6m, 5y)
    * @return a list of historical prices for the symbol/range passed in
    */
-  public List<IexHistoricalPrice> getHistoricalPrices(final String symbol, final String range,
-      final String date) {
-    if (date == null) { return iexClient.getHistoricalPrices(symbol, range); }
-    else { return iexClient.getHistoricalPrices(symbol, range, date); }
+  public List<IexHistoricalPrice> getHistoricalPrices(final String token, final String symbol,
+      final String range, final String date) {
+    if (date == null) { return iexClient.getHistoricalPrices(token, symbol, range); }
+    else { return iexClient.getHistoricalPrices(token, symbol, range, date); }
     }
 
 }

--- a/src/main/java/org/galatea/starter/service/IexService.java
+++ b/src/main/java/org/galatea/starter/service/IexService.java
@@ -52,12 +52,19 @@ public class IexService {
    *
    * @param symbol stock symbol for historical prices
    * @param range time range for historical prices (e.g. 3m, 6m, 5y)
+   * @param date date as String; format YYYYMMDD
    * @return a list of historical prices for the symbol/range passed in
    */
   public List<IexHistoricalPrice> getHistoricalPrices(final String symbol, final String range,
       final String date) {
-    if (date == null) { return iexClient.getHistoricalPrices(token, symbol, range); }
-    else { return iexClient.getHistoricalPrices(token, symbol, range, date); }
-    }
+    /* range and date path variables are optional, so they can be passed as empty strings,
+    as implemented below.(IEX API handles null and empty string path variables identically.)
+    Alternatively, using method overloading, we would need four getHistoricalPrices methods
+    that include/exclude range and/or date, which seems unnecessary.
+     */
+    final String clientRange = (range == null) ? "" : range;
+    final String clientDate = (date == null) ? "" : date;
 
+    return iexClient.getHistoricalPrices(token, symbol, clientRange, clientDate);
+    }
 }

--- a/src/main/java/org/galatea/starter/service/IexService.java
+++ b/src/main/java/org/galatea/starter/service/IexService.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.galatea.starter.domain.IexLastTradedPrice;
 import org.galatea.starter.domain.IexSymbol;
+import org.galatea.starter.domain.IexHistoricalPrice;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 
@@ -43,6 +44,17 @@ public class IexService {
     } else {
       return iexClient.getLastTradedPriceForSymbols(symbols.toArray(new String[0]));
     }
+  }
+
+  /**
+   * Get historical prices given stock and time range.
+   *
+   * @param symbol stock symbol for historical prices
+   * @param range time range for historical prices (e.g. 3m, 6m, 5y)
+   * @return a list of historical prices for the symbol/range passed in
+   */
+  public List<IexHistoricalPrice> getHistoricalPrices(final String symbol, final String range) {
+    return iexClient.getHistoricalPrices(symbol, range);
   }
 
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,6 +25,7 @@ mvc:
    iex:
       getAllSymbolsPath: /iex/symbols
       getLastTradedPricePath: /iex/lastTradedPrice
+      getHistoricalPricesPath: /iex/historicalPrices
    max-size-trace-payload: 50000
 jms:
    listener-concurrency: 1-5

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,7 +17,6 @@ spring:
       database-platform: org.hibernate.dialect.MySQL5Dialect
 
 mvc:
-   iexToken: xyz
    settleMissionPath: /settlementEngine
    updateMissionPath: /settlementEngine/mission/
    getMissionPath: /settlementEngine/mission/

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -57,7 +57,7 @@ spring:
       username: sa
       password:
    rest:
-      iexBasePath: https://api.iextrading.com/1.0
+      iexBasePath: https://cloud.iexapis.com/stable/
 # set debug to get spring to log the classpath (and other things) on startup
 debug: true
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,6 +17,7 @@ spring:
       database-platform: org.hibernate.dialect.MySQL5Dialect
 
 mvc:
+   iexToken: xyz
    settleMissionPath: /settlementEngine
    updateMissionPath: /settlementEngine/mission/
    getMissionPath: /settlementEngine/mission/

--- a/src/test/java/org/galatea/starter/entrypoint/IexRestControllerTest.java
+++ b/src/test/java/org/galatea/starter/entrypoint/IexRestControllerTest.java
@@ -1,11 +1,13 @@
 package org.galatea.starter.entrypoint;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import feign.FeignException;
 import java.math.BigDecimal;
 import java.util.Collections;
 import junitparams.JUnitParamsRunner;
@@ -21,6 +23,7 @@ import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.web.util.NestedServletException;
 
 
 @RequiredArgsConstructor
@@ -57,97 +60,105 @@ public class IexRestControllerTest extends ASpringTest {
         .andReturn();
   }
 
-//  @Test
-//  public void testGetLastTradedPrice() throws Exception {
-//
-//    MvcResult result = this.mvc.perform(
-//        org.springframework.test.web.servlet.request.MockMvcRequestBuilders
-//            .get("/iex/lastTradedPrice?token=DUMMY_TKN&symbols=FB")
-//            // This URL will be hit by the MockMvc client. The result is configured in the file
-//            // src/test/resources/wiremock/mappings/mapping-lastTradedPrice.json
-//            .accept(MediaType.APPLICATION_JSON_VALUE))
-//        .andExpect(status().isOk())
-//        .andExpect(jsonPath("$[0].symbol", is("FB")))
-//        .andExpect(jsonPath("$[0].price").value(new BigDecimal("186.3011")))
-//        .andReturn();
-//  }
-//
-//  @Test
-//  public void testGetLastTradedPriceEmpty() throws Exception {
-//
-//    MvcResult result = this.mvc.perform(
-//        org.springframework.test.web.servlet.request.MockMvcRequestBuilders
-//            .get("/iex/lastTradedPrice?symbols=")
-//            .accept(MediaType.APPLICATION_JSON_VALUE))
-//        .andExpect(status().isOk())
-//        .andExpect(jsonPath("$", is(Collections.emptyList())))
-//        .andReturn();
-//  }
-//
-//  @Test
-//  public void testGetHistoricalPrices() throws Exception {
-//
-//    MvcResult result = this.mvc.perform(
-//            org.springframework.test.web.servlet.request.MockMvcRequestBuilders
-//                .get("/iex/historicalPrices?token=DUMMY_TKN&symbol=AAPL&range=5d")
-//                // This URL will be hit by the MockMvc client. The result is configured in the file
-//                // src/test/resources/wiremock/mappings/mapping-lastTradedPrice.json
-//                .accept(MediaType.APPLICATION_JSON_VALUE))
-//        .andExpect(status().isOk())
-//        .andExpect(jsonPath("$[0].close", is(166.23)))
-//        .andExpect(jsonPath("$[0].high", is(168.91)))
-//        .andExpect(jsonPath("$[0].low", is(165.55)))
-//        .andExpect(jsonPath("$[0].open", is(168.47)))
-//        .andExpect(jsonPath("$[0].symbol", is("AAPL")))
-//        .andExpect(jsonPath("$[0].volume", is(76678441)))
-//        .andExpect(jsonPath("$[0].date", is("2022-03-03")))
-//        .andExpect(jsonPath("$[2].close", is(159.3)))
-//        .andExpect(jsonPath("$[2].high", is(165.02)))
-//        .andExpect(jsonPath("$[2].low", is(159.04)))
-//        .andExpect(jsonPath("$[2].open", is(163.36)))
-//        .andExpect(jsonPath("$[2].symbol", is("AAPL")))
-//        .andExpect(jsonPath("$[2].volume", is(96418845)))
-//        .andExpect(jsonPath("$[2].date", is("2022-03-07")))
-//        .andReturn();
-//  }
-//
-//  @Test
-//  public void testGetHistoricalPricesDate() throws Exception {
-//
-//    MvcResult result = this.mvc.perform(
-//            org.springframework.test.web.servlet.request.MockMvcRequestBuilders
-//                .get("/iex/historicalPrices?token=DUMMY_TKN&symbol=twtr&range=date&date=20200220")
-//                // This URL will be hit by the MockMvc client. The result is configured in the file
-//                // src/test/resources/wiremock/mappings/mapping-lastTradedPrice.json
-//                .accept(MediaType.APPLICATION_JSON_VALUE))
-//        .andExpect(status().isOk())
-//        .andExpect(jsonPath("$[0].close", is(38.785)))
-//        .andExpect(jsonPath("$[0].high", is(38.785)))
-//        .andExpect(jsonPath("$[0].low", is(38.785)))
-//        .andExpect(jsonPath("$[0].open", is(38.785)))
-//        .andExpect(jsonPath("$[0].symbol", is(nullValue())))
-//        .andExpect(jsonPath("$[0].volume", is(100)))
-//        .andExpect(jsonPath("$[0].date", is("2020-02-20")))
-//        .andExpect(jsonPath("$[9].close", is(38.56)))
-//        .andExpect(jsonPath("$[9].high", is(38.56)))
-//        .andExpect(jsonPath("$[9].low", is(38.485)))
-//        .andExpect(jsonPath("$[9].open", is(38.535)))
-//        .andExpect(jsonPath("$[9].symbol", is(nullValue())))
-//        .andExpect(jsonPath("$[9].volume", is(400)))
-//        .andExpect(jsonPath("$[9].date", is("2020-02-20")))
-//        .andReturn();
-//  }
-//
-//  @Test
-//  public void testGetHistoricalPricesNoRange() throws Exception {
-//
-//    MvcResult result = this.mvc.perform(
-//            org.springframework.test.web.servlet.request.MockMvcRequestBuilders
-//                .get("/iex/historicalPrices?token=DUMMY_TKN&symbol=twtr")
-//                // This URL will be hit by the MockMvc client. The result is configured in the file
-//                // src/test/resources/wiremock/mappings/mapping-lastTradedPrice.json
-//                .accept(MediaType.APPLICATION_JSON_VALUE))
-//        .andExpect(status().isBadRequest())
-//        .andReturn();
-//  }
+  @Test
+  public void testGetLastTradedPrice() throws Exception {
+
+    MvcResult result = this.mvc.perform(
+        org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+            .get("/iex/lastTradedPrice?token=DUMMY_TKN&symbols=FB")
+            // This URL will be hit by the MockMvc client. The result is configured in the file
+            // src/test/resources/wiremock/mappings/mapping-lastTradedPrice.json
+            .accept(MediaType.APPLICATION_JSON_VALUE))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].symbol", is("FB")))
+        .andExpect(jsonPath("$[0].price").value(new BigDecimal("186.3011")))
+        .andReturn();
+  }
+
+  @Test
+  public void testGetLastTradedPriceEmpty() throws Exception {
+
+    MvcResult result = this.mvc.perform(
+        org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+            .get("/iex/lastTradedPrice?token=DUMMY_TKN&symbols=")
+            .accept(MediaType.APPLICATION_JSON_VALUE))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$", is(Collections.emptyList())))
+        .andReturn();
+  }
+
+  @Test
+  public void testGetHistoricalPrices() throws Exception {
+
+    MvcResult result = this.mvc.perform(
+            org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                .get("/iex/historicalPrices?token=DUMMY_TKN&symbol=AAPL&range=5d")
+                .accept(MediaType.APPLICATION_JSON_VALUE))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].close", is(166.23)))
+        .andExpect(jsonPath("$[0].high", is(168.91)))
+        .andExpect(jsonPath("$[0].low", is(165.55)))
+        .andExpect(jsonPath("$[0].open", is(168.47)))
+        .andExpect(jsonPath("$[0].symbol", is("AAPL")))
+        .andExpect(jsonPath("$[0].volume", is(76678441)))
+        .andExpect(jsonPath("$[0].date", is("2022-03-03")))
+        .andExpect(jsonPath("$[2].close", is(159.3)))
+        .andExpect(jsonPath("$[2].high", is(165.02)))
+        .andExpect(jsonPath("$[2].low", is(159.04)))
+        .andExpect(jsonPath("$[2].open", is(163.36)))
+        .andExpect(jsonPath("$[2].symbol", is("AAPL")))
+        .andExpect(jsonPath("$[2].volume", is(96418845)))
+        .andExpect(jsonPath("$[2].date", is("2022-03-07")))
+        .andReturn();
+  }
+
+  @Test
+  public void testGetHistoricalPricesDate() throws Exception {
+
+    MvcResult result = this.mvc.perform(
+            org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                .get("/iex/historicalPrices?token=DUMMY_TKN&symbol=twtr&range=date&date=20200220")
+                .accept(MediaType.APPLICATION_JSON_VALUE))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].close", is(38.785)))
+        .andExpect(jsonPath("$[0].high", is(38.785)))
+        .andExpect(jsonPath("$[0].low", is(38.785)))
+        .andExpect(jsonPath("$[0].open", is(38.785)))
+        .andExpect(jsonPath("$[0].symbol", is(nullValue())))
+        .andExpect(jsonPath("$[0].volume", is(100)))
+        .andExpect(jsonPath("$[0].date", is("2020-02-20")))
+        .andExpect(jsonPath("$[9].close", is(38.56)))
+        .andExpect(jsonPath("$[9].high", is(38.56)))
+        .andExpect(jsonPath("$[9].low", is(38.485)))
+        .andExpect(jsonPath("$[9].open", is(38.535)))
+        .andExpect(jsonPath("$[9].symbol", is(nullValue())))
+        .andExpect(jsonPath("$[9].volume", is(400)))
+        .andExpect(jsonPath("$[9].date", is("2020-02-20")))
+        .andReturn();
+  }
+
+  @Test
+  public void testGetHistoricalPricesNoRange() throws Exception {
+
+    MvcResult result = this.mvc.perform(
+            org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                .get("/iex/historicalPrices?token=DUMMY_TKN&symbol=twtr")
+                .accept(MediaType.APPLICATION_JSON_VALUE))
+        .andExpect(status().isBadRequest())
+        .andExpect(status().reason(containsString("Required String parameter 'range' is not present")))
+        .andReturn();
+  }
+
+  @Test(expected=NestedServletException.class)
+  public void testGetHistoricalInvalidSymbol() throws Exception {
+
+    MvcResult result = this.mvc.perform(
+            org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                .get("/iex/historicalPrices?token=DUMMY_TKN&symbol=abcde&range=5d")
+                .accept(MediaType.APPLICATION_JSON_VALUE))
+        .andExpect(status().isInternalServerError())
+        .andExpect(status().reason(containsString("status 404 reading IexClient#getHistoricalPrices(String,String,String)")))
+        .andReturn();
+  }
+
 }

--- a/src/test/java/org/galatea/starter/entrypoint/IexRestControllerTest.java
+++ b/src/test/java/org/galatea/starter/entrypoint/IexRestControllerTest.java
@@ -81,4 +81,24 @@ public class IexRestControllerTest extends ASpringTest {
         .andExpect(jsonPath("$", is(Collections.emptyList())))
         .andReturn();
   }
+
+  @Test
+  public void testGetHistoricalPrices() throws Exception {
+
+    MvcResult result = this.mvc.perform(
+            org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                .get("/iex/historicalPrice?symbol=AAPL&range=5d")
+                // This URL will be hit by the MockMvc client. The result is configured in the file
+                // src/test/resources/wiremock/mappings/mapping-lastTradedPrice.json
+                .accept(MediaType.APPLICATION_JSON_VALUE))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].close", is(116.59)))
+        .andExpect(jsonPath("$[0].high", is(117.49)))
+        .andExpect(jsonPath("$[0].low", is(116.22)))
+        .andExpect(jsonPath("$[0].open", is(116.57)))
+        .andExpect(jsonPath("$[0].symbol", is("AAPL")))
+        .andExpect(jsonPath("$[0].volume", is(46691331)))
+        .andExpect(jsonPath("$[0].date", is("2020-01-26")))
+        .andReturn();
+  }
 }

--- a/src/test/java/org/galatea/starter/entrypoint/IexRestControllerTest.java
+++ b/src/test/java/org/galatea/starter/entrypoint/IexRestControllerTest.java
@@ -1,6 +1,8 @@
 package org.galatea.starter.entrypoint;
 
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.core.IsNull.nullValue;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -45,7 +47,7 @@ public class IexRestControllerTest extends ASpringTest {
     MvcResult result = this.mvc.perform(
         // note that we were are testing the fuse REST end point here, not the IEX end point.
         // the fuse end point in turn calls the IEX end point, which is WireMocked for this test.
-        org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get("/iex/symbols")
+        org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get("/iex/symbols?token=DUMMY_TKN")
             .accept(MediaType.APPLICATION_JSON_VALUE))
         .andExpect(status().isOk())
         // some simple validations, in practice I would expect these to be much more comprehensive.
@@ -55,49 +57,97 @@ public class IexRestControllerTest extends ASpringTest {
         .andReturn();
   }
 
-  @Test
-  public void testGetLastTradedPrice() throws Exception {
-
-    MvcResult result = this.mvc.perform(
-        org.springframework.test.web.servlet.request.MockMvcRequestBuilders
-            .get("/iex/lastTradedPrice?symbols=FB")
-            // This URL will be hit by the MockMvc client. The result is configured in the file
-            // src/test/resources/wiremock/mappings/mapping-lastTradedPrice.json
-            .accept(MediaType.APPLICATION_JSON_VALUE))
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$[0].symbol", is("FB")))
-        .andExpect(jsonPath("$[0].price").value(new BigDecimal("186.3011")))
-        .andReturn();
-  }
-
-  @Test
-  public void testGetLastTradedPriceEmpty() throws Exception {
-
-    MvcResult result = this.mvc.perform(
-        org.springframework.test.web.servlet.request.MockMvcRequestBuilders
-            .get("/iex/lastTradedPrice?symbols=")
-            .accept(MediaType.APPLICATION_JSON_VALUE))
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$", is(Collections.emptyList())))
-        .andReturn();
-  }
-
-  @Test
-  public void testGetHistoricalPrices() throws Exception {
-
-    MvcResult result = this.mvc.perform(
-            org.springframework.test.web.servlet.request.MockMvcRequestBuilders
-                .get("/iex/historicalPrices?symbol=AAPL&range=5d")
-                // This URL will be hit by the MockMvc client. The result is configured in the file
-                // src/test/resources/wiremock/mappings/mapping-lastTradedPrice.json
-                .accept(MediaType.APPLICATION_JSON_VALUE))
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$[0].close", is(116.59)))
-        .andExpect(jsonPath("$[0].high", is(117.49)))
-        .andExpect(jsonPath("$[0].low", is(116.22)))
-        .andExpect(jsonPath("$[0].open", is(116.57)))
-        .andExpect(jsonPath("$[0].symbol", is("AAPL")))
-        .andExpect(jsonPath("$[0].volume", is(46691331)))
-        .andReturn();
-  }
+//  @Test
+//  public void testGetLastTradedPrice() throws Exception {
+//
+//    MvcResult result = this.mvc.perform(
+//        org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+//            .get("/iex/lastTradedPrice?token=DUMMY_TKN&symbols=FB")
+//            // This URL will be hit by the MockMvc client. The result is configured in the file
+//            // src/test/resources/wiremock/mappings/mapping-lastTradedPrice.json
+//            .accept(MediaType.APPLICATION_JSON_VALUE))
+//        .andExpect(status().isOk())
+//        .andExpect(jsonPath("$[0].symbol", is("FB")))
+//        .andExpect(jsonPath("$[0].price").value(new BigDecimal("186.3011")))
+//        .andReturn();
+//  }
+//
+//  @Test
+//  public void testGetLastTradedPriceEmpty() throws Exception {
+//
+//    MvcResult result = this.mvc.perform(
+//        org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+//            .get("/iex/lastTradedPrice?symbols=")
+//            .accept(MediaType.APPLICATION_JSON_VALUE))
+//        .andExpect(status().isOk())
+//        .andExpect(jsonPath("$", is(Collections.emptyList())))
+//        .andReturn();
+//  }
+//
+//  @Test
+//  public void testGetHistoricalPrices() throws Exception {
+//
+//    MvcResult result = this.mvc.perform(
+//            org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+//                .get("/iex/historicalPrices?token=DUMMY_TKN&symbol=AAPL&range=5d")
+//                // This URL will be hit by the MockMvc client. The result is configured in the file
+//                // src/test/resources/wiremock/mappings/mapping-lastTradedPrice.json
+//                .accept(MediaType.APPLICATION_JSON_VALUE))
+//        .andExpect(status().isOk())
+//        .andExpect(jsonPath("$[0].close", is(166.23)))
+//        .andExpect(jsonPath("$[0].high", is(168.91)))
+//        .andExpect(jsonPath("$[0].low", is(165.55)))
+//        .andExpect(jsonPath("$[0].open", is(168.47)))
+//        .andExpect(jsonPath("$[0].symbol", is("AAPL")))
+//        .andExpect(jsonPath("$[0].volume", is(76678441)))
+//        .andExpect(jsonPath("$[0].date", is("2022-03-03")))
+//        .andExpect(jsonPath("$[2].close", is(159.3)))
+//        .andExpect(jsonPath("$[2].high", is(165.02)))
+//        .andExpect(jsonPath("$[2].low", is(159.04)))
+//        .andExpect(jsonPath("$[2].open", is(163.36)))
+//        .andExpect(jsonPath("$[2].symbol", is("AAPL")))
+//        .andExpect(jsonPath("$[2].volume", is(96418845)))
+//        .andExpect(jsonPath("$[2].date", is("2022-03-07")))
+//        .andReturn();
+//  }
+//
+//  @Test
+//  public void testGetHistoricalPricesDate() throws Exception {
+//
+//    MvcResult result = this.mvc.perform(
+//            org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+//                .get("/iex/historicalPrices?token=DUMMY_TKN&symbol=twtr&range=date&date=20200220")
+//                // This URL will be hit by the MockMvc client. The result is configured in the file
+//                // src/test/resources/wiremock/mappings/mapping-lastTradedPrice.json
+//                .accept(MediaType.APPLICATION_JSON_VALUE))
+//        .andExpect(status().isOk())
+//        .andExpect(jsonPath("$[0].close", is(38.785)))
+//        .andExpect(jsonPath("$[0].high", is(38.785)))
+//        .andExpect(jsonPath("$[0].low", is(38.785)))
+//        .andExpect(jsonPath("$[0].open", is(38.785)))
+//        .andExpect(jsonPath("$[0].symbol", is(nullValue())))
+//        .andExpect(jsonPath("$[0].volume", is(100)))
+//        .andExpect(jsonPath("$[0].date", is("2020-02-20")))
+//        .andExpect(jsonPath("$[9].close", is(38.56)))
+//        .andExpect(jsonPath("$[9].high", is(38.56)))
+//        .andExpect(jsonPath("$[9].low", is(38.485)))
+//        .andExpect(jsonPath("$[9].open", is(38.535)))
+//        .andExpect(jsonPath("$[9].symbol", is(nullValue())))
+//        .andExpect(jsonPath("$[9].volume", is(400)))
+//        .andExpect(jsonPath("$[9].date", is("2020-02-20")))
+//        .andReturn();
+//  }
+//
+//  @Test
+//  public void testGetHistoricalPricesNoRange() throws Exception {
+//
+//    MvcResult result = this.mvc.perform(
+//            org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+//                .get("/iex/historicalPrices?token=DUMMY_TKN&symbol=twtr")
+//                // This URL will be hit by the MockMvc client. The result is configured in the file
+//                // src/test/resources/wiremock/mappings/mapping-lastTradedPrice.json
+//                .accept(MediaType.APPLICATION_JSON_VALUE))
+//        .andExpect(status().isBadRequest())
+//        .andReturn();
+//  }
 }

--- a/src/test/java/org/galatea/starter/entrypoint/IexRestControllerTest.java
+++ b/src/test/java/org/galatea/starter/entrypoint/IexRestControllerTest.java
@@ -88,7 +88,7 @@ public class IexRestControllerTest extends ASpringTest {
   }
 
   @Test
-  public void testGetHistoricalPrices() throws Exception {
+  public void testGetHistoricalPricesNoDate() throws Exception {
 
     MvcResult result = this.mvc.perform(
             org.springframework.test.web.servlet.request.MockMvcRequestBuilders
@@ -142,10 +142,47 @@ public class IexRestControllerTest extends ASpringTest {
 
     MvcResult result = this.mvc.perform(
             org.springframework.test.web.servlet.request.MockMvcRequestBuilders
-                .get("/iex/historicalPrices?token=DUMMY_TKN&symbol=twtr")
+                .get("/iex/historicalPrices?token=DUMMY_TKN&symbol=FB")
+                .accept(MediaType.APPLICATION_JSON_VALUE))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].close", is(219.55)))
+        .andExpect(jsonPath("$[0].high", is(230.42)))
+        .andExpect(jsonPath("$[0].low", is(218.7701)))
+        .andExpect(jsonPath("$[0].open", is(228.46)))
+        .andExpect(jsonPath("$[0].symbol", is("FB")))
+        .andExpect(jsonPath("$[0].volume", is(46156943)))
+        .andExpect(jsonPath("$[0].date", is("2022-02-11")))
+        .andExpect(jsonPath("$[4].close", is(207.71)))
+        .andExpect(jsonPath("$[4].high", is(217.5)))
+        .andExpect(jsonPath("$[4].low", is(207.1601)))
+        .andExpect(jsonPath("$[4].open", is(214.02)))
+        .andExpect(jsonPath("$[4].symbol", is("FB")))
+        .andExpect(jsonPath("$[4].volume", is(38747533)))
+        .andExpect(jsonPath("$[4].date", is("2022-02-17")))
+        .andReturn();
+  }
+
+  @Test()
+  public void testGetHistoricalNullSymbol() throws Exception {
+
+    MvcResult result = this.mvc.perform(
+            org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                .get("/iex/historicalPrices?token=DUMMY_TKN&range=5d")
                 .accept(MediaType.APPLICATION_JSON_VALUE))
         .andExpect(status().isBadRequest())
-        .andExpect(status().reason(containsString("Required String parameter 'range' is not present")))
+        .andExpect(status().reason(containsString("Required String parameter 'symbol' is not present")))
+        .andReturn();
+  }
+
+  @Test(expected=NestedServletException.class)
+  public void testGetHistoricalEmptyStringSymbol() throws Exception {
+
+    MvcResult result = this.mvc.perform(
+            org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                .get("/iex/historicalPrices?token=DUMMY_TKN&symbol=&range=5d")
+                .accept(MediaType.APPLICATION_JSON_VALUE))
+        .andExpect(status().isInternalServerError())
+        .andExpect(status().reason(containsString("status 404 reading IexClient#getHistoricalPrices(String,String,String)")))
         .andReturn();
   }
 
@@ -160,5 +197,7 @@ public class IexRestControllerTest extends ASpringTest {
         .andExpect(status().reason(containsString("status 404 reading IexClient#getHistoricalPrices(String,String,String)")))
         .andReturn();
   }
+
+
 
 }

--- a/src/test/java/org/galatea/starter/entrypoint/IexRestControllerTest.java
+++ b/src/test/java/org/galatea/starter/entrypoint/IexRestControllerTest.java
@@ -87,7 +87,7 @@ public class IexRestControllerTest extends ASpringTest {
 
     MvcResult result = this.mvc.perform(
             org.springframework.test.web.servlet.request.MockMvcRequestBuilders
-                .get("/iex/historicalPrice?symbol=AAPL&range=5d")
+                .get("/iex/historicalPrices?symbol=AAPL&range=5d")
                 // This URL will be hit by the MockMvc client. The result is configured in the file
                 // src/test/resources/wiremock/mappings/mapping-lastTradedPrice.json
                 .accept(MediaType.APPLICATION_JSON_VALUE))
@@ -98,7 +98,6 @@ public class IexRestControllerTest extends ASpringTest {
         .andExpect(jsonPath("$[0].open", is(116.57)))
         .andExpect(jsonPath("$[0].symbol", is("AAPL")))
         .andExpect(jsonPath("$[0].volume", is(46691331)))
-        .andExpect(jsonPath("$[0].date", is("2020-01-26")))
         .andReturn();
   }
 }

--- a/src/test/resources/wiremock/mappings/mapping-historicalPrices.json
+++ b/src/test/resources/wiremock/mappings/mapping-historicalPrices.json
@@ -2,7 +2,7 @@
   "id" : "16369e06-78d4-40a7-98d1-3dbe0ba82fc9",
   "name" : "historical_prices",
   "request" : {
-    "url" : "/stock/aapl/chart/5d",
+    "url" : "/stock/AAPL/chart/5d",
     "method" : "GET"
   },
   "response" : {
@@ -15,7 +15,7 @@
         "open":116.57,
         "symbol":"AAPL",
         "volume":46691331,
-        "date":"2020-01-26",
+        "date":"2020-01-26"
       }
     ],
     "headers" : {

--- a/src/test/resources/wiremock/mappings/mapping-historicalPrices.json
+++ b/src/test/resources/wiremock/mappings/mapping-historicalPrices.json
@@ -191,7 +191,54 @@
         "method": "GET"
       },
       "response": {
+        "status": 400,
+        "jsonBody": [
+          {
+            "timestamp": 1646853826848,
+            "status": 400,
+            "error": "Bad Request",
+            "message": "Required String parameter 'range' is not present",
+            "path": "/iex/historicalPrices"
+          }
+          ],
+        "headers": {
+          "Server": "nginx",
+          "Date": "Thu, 08 Aug 2019 14:08:53 GMT",
+          "Content-Type": "application/json; charset=utf-8",
+          "Connection": "keep-alive",
+          "set-cookie": "ctoken=958c0e17a3f542a2a13ef676b670326d; Domain=.iextrading.com; Path=/; Expires=Fri, 09 Aug 2019 02:08:53 GMT; Secure",
+          "Content-Security-Policy": "default-src 'self'; child-src 'none'; object-src 'none'; style-src 'self' 'unsafe-inline'; font-src data:; frame-src 'self'; connect-src 'self' https://auth.iextrading.com https://api.iextrading.com https://api.iextrading.com wss://iextrading.com wss://tops.iextrading.com wss://api.iextrading.com wss://iextrading.com https://iextrading.com/member-center; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google-analytics.com/analytics.js;",
+          "X-Content-Security-Policy": "default-src 'self'; child-src 'none'; object-src 'none'; style-src 'self' 'unsafe-inline'; font-src data:; frame-src 'self'; connect-src 'self' https://auth.iextrading.com https://api.iextrading.com https://api.iextrading.com wss://iextrading.com wss://tops.iextrading.com wss://api.iextrading.com wss://iextrading.com https://iextrading.com/member-center; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google-analytics.com/analytics.js;",
+          "Frame-Options": "SAMEORIGIN",
+          "X-Frame-Options": "SAMEORIGIN",
+          "X-Content-Type-Options": "nosniff",
+          "Strict-Transport-Security": "max-age=15768000",
+          "Access-Control-Allow-Origin": "*",
+          "Access-Control-Allow-Credentials": "true",
+          "Access-Control-Allow-Methods": "GET, OPTIONS",
+          "Access-Control-Allow-Headers": "Origin, X-Requested-With, Content-Type, Accept"
+        }
+      },
+      "uuid": "16369e06-78d4-40a7-98d1-3dbe0ba82fc9",
+      "persistent": true,
+      "insertionIndex": 5
+    },
+    {
+      "id": "16369e06-78d4-40a7-98d1-3dbe0ba82fc9",
+      "name": "historical_prices_invalid_symbol",
+      "request": {
+        "url": "/stock/abcde/chart/5d?token=DUMMY_TKN",
+        "method": "GET"
+      },
+      "response": {
         "status": 500,
+        "jsonBody": {
+          "timestamp": 1646853826848,
+          "status": 500,
+          "error": "Internal Server Error",
+          "message": "org.springframework.web.util.NestedServletException: Request processing failed; nested exception is feign.FeignException: status 404 reading IexClient#getHistoricalPrices(String,String,String); content:\nUnknown symbol",
+          "path": "/iex/historicalPrices"
+        },
         "headers": {
           "Server": "nginx",
           "Date": "Thu, 08 Aug 2019 14:08:53 GMT",

--- a/src/test/resources/wiremock/mappings/mapping-historicalPrices.json
+++ b/src/test/resources/wiremock/mappings/mapping-historicalPrices.json
@@ -2,9 +2,9 @@
   "mappings": [
     {
       "id": "16369e06-78d4-40a7-98d1-3dbe0ba82fc9",
-      "name": "historical_prices",
+      "name": "historical_prices_no_date",
       "request": {
-        "url": "/stock/AAPL/chart/5d?token=DUMMY_TKN",
+        "url": "/stock/AAPL/chart/5d/?token=DUMMY_TKN",
         "method": "GET"
       },
       "response": {
@@ -187,20 +187,134 @@
       "id": "16369e06-78d4-40a7-98d1-3dbe0ba82fc9",
       "name": "historical_prices_no_range",
       "request": {
-        "url": "/stock/twtr/chart?token=DUMMY_TKN",
+        "url": "/stock/FB/chart//?token=DUMMY_TKN",
+        "method": "GET"
+      },
+      "response": {
+        "status": 200,
+        "jsonBody": [
+          {
+            "close":219.55,
+            "high":230.42,
+            "low":218.7701,
+            "open":228.46,
+            "symbol":"FB",
+            "volume":46156943,
+            "date":"2022-02-11"
+          },
+          {
+            "close":217.7,
+            "high":221,
+            "low":214.78,
+            "open":219.31,
+            "symbol":"FB",
+            "volume":38184035,
+            "date":"2022-02-14"
+          },
+          {
+            "close":221,
+            "high":221.15,
+            "low":215.06,
+            "open":220.47,
+            "symbol":"FB",
+            "volume":42685473,
+            "date":"2022-02-15"
+          },
+          {
+            "close":216.54,
+            "high":217.46,
+            "low":212.36,
+            "open":212.41,
+            "symbol":"FB",
+            "volume":45817457,
+            "date":"2022-02-16"
+          },
+          {
+            "close":207.71,
+            "high":217.5,
+            "low":207.1601,
+            "open":214.02,
+            "symbol":"FB",
+            "volume":38747533,
+            "date":"2022-02-17"
+          }
+        ],
+        "headers": {
+          "Server": "nginx",
+          "Date": "Thu, 08 Aug 2019 14:08:53 GMT",
+          "Content-Type": "application/json; charset=utf-8",
+          "Connection": "keep-alive",
+          "set-cookie": "ctoken=958c0e17a3f542a2a13ef676b670326d; Domain=.iextrading.com; Path=/; Expires=Fri, 09 Aug 2019 02:08:53 GMT; Secure",
+          "Content-Security-Policy": "default-src 'self'; child-src 'none'; object-src 'none'; style-src 'self' 'unsafe-inline'; font-src data:; frame-src 'self'; connect-src 'self' https://auth.iextrading.com https://api.iextrading.com https://api.iextrading.com wss://iextrading.com wss://tops.iextrading.com wss://api.iextrading.com wss://iextrading.com https://iextrading.com/member-center; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google-analytics.com/analytics.js;",
+          "X-Content-Security-Policy": "default-src 'self'; child-src 'none'; object-src 'none'; style-src 'self' 'unsafe-inline'; font-src data:; frame-src 'self'; connect-src 'self' https://auth.iextrading.com https://api.iextrading.com https://api.iextrading.com wss://iextrading.com wss://tops.iextrading.com wss://api.iextrading.com wss://iextrading.com https://iextrading.com/member-center; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google-analytics.com/analytics.js;",
+          "Frame-Options": "SAMEORIGIN",
+          "X-Frame-Options": "SAMEORIGIN",
+          "X-Content-Type-Options": "nosniff",
+          "Strict-Transport-Security": "max-age=15768000",
+          "Access-Control-Allow-Origin": "*",
+          "Access-Control-Allow-Credentials": "true",
+          "Access-Control-Allow-Methods": "GET, OPTIONS",
+          "Access-Control-Allow-Headers": "Origin, X-Requested-With, Content-Type, Accept"
+        }
+      },
+      "uuid": "16369e06-78d4-40a7-98d1-3dbe0ba82fc9",
+      "persistent": true,
+      "insertionIndex": 5
+    },
+    {
+      "id": "16369e06-78d4-40a7-98d1-3dbe0ba82fc9",
+      "name": "historical_prices_null_symbol",
+      "request": {
+        "url": "/stock/chart/5d?token=DUMMY_TKN",
         "method": "GET"
       },
       "response": {
         "status": 400,
-        "jsonBody": [
-          {
-            "timestamp": 1646853826848,
-            "status": 400,
-            "error": "Bad Request",
-            "message": "Required String parameter 'range' is not present",
-            "path": "/iex/historicalPrices"
-          }
-          ],
+        "jsonBody": {
+          "timestamp": 1646853826848,
+          "status": 400,
+          "error": "Bad Request",
+          "message": "Required String parameter 'symbol' is not present",
+          "path": "/iex/historicalPrices"
+        },
+        "headers": {
+          "Server": "nginx",
+          "Date": "Thu, 08 Aug 2019 14:08:53 GMT",
+          "Content-Type": "application/json; charset=utf-8",
+          "Connection": "keep-alive",
+          "set-cookie": "ctoken=958c0e17a3f542a2a13ef676b670326d; Domain=.iextrading.com; Path=/; Expires=Fri, 09 Aug 2019 02:08:53 GMT; Secure",
+          "Content-Security-Policy": "default-src 'self'; child-src 'none'; object-src 'none'; style-src 'self' 'unsafe-inline'; font-src data:; frame-src 'self'; connect-src 'self' https://auth.iextrading.com https://api.iextrading.com https://api.iextrading.com wss://iextrading.com wss://tops.iextrading.com wss://api.iextrading.com wss://iextrading.com https://iextrading.com/member-center; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google-analytics.com/analytics.js;",
+          "X-Content-Security-Policy": "default-src 'self'; child-src 'none'; object-src 'none'; style-src 'self' 'unsafe-inline'; font-src data:; frame-src 'self'; connect-src 'self' https://auth.iextrading.com https://api.iextrading.com https://api.iextrading.com wss://iextrading.com wss://tops.iextrading.com wss://api.iextrading.com wss://iextrading.com https://iextrading.com/member-center; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google-analytics.com/analytics.js;",
+          "Frame-Options": "SAMEORIGIN",
+          "X-Frame-Options": "SAMEORIGIN",
+          "X-Content-Type-Options": "nosniff",
+          "Strict-Transport-Security": "max-age=15768000",
+          "Access-Control-Allow-Origin": "*",
+          "Access-Control-Allow-Credentials": "true",
+          "Access-Control-Allow-Methods": "GET, OPTIONS",
+          "Access-Control-Allow-Headers": "Origin, X-Requested-With, Content-Type, Accept"
+        }
+      },
+      "uuid": "16369e06-78d4-40a7-98d1-3dbe0ba82fc9",
+      "persistent": true,
+      "insertionIndex": 5
+    },
+    {
+      "id": "16369e06-78d4-40a7-98d1-3dbe0ba82fc9",
+      "name": "historical_prices_empty_string_symbol",
+      "request": {
+        "url": "/stock//chart/5d/?token=DUMMY_TKN",
+        "method": "GET"
+      },
+      "response": {
+        "status": 500,
+        "jsonBody": {
+          "timestamp": 1646853826848,
+          "status": 500,
+          "error": "Internal Server Error",
+          "message": "org.springframework.web.util.NestedServletException: Request processing failed; nested exception is feign.FeignException: status 404 reading IexClient#getHistoricalPrices(String,String,String); content:\nUnknown symbol",
+          "path": "/iex/historicalPrices"
+        },
         "headers": {
           "Server": "nginx",
           "Date": "Thu, 08 Aug 2019 14:08:53 GMT",
@@ -227,7 +341,7 @@
       "id": "16369e06-78d4-40a7-98d1-3dbe0ba82fc9",
       "name": "historical_prices_invalid_symbol",
       "request": {
-        "url": "/stock/abcde/chart/5d?token=DUMMY_TKN",
+        "url": "/stock/abcde/chart/5d/?token=DUMMY_TKN",
         "method": "GET"
       },
       "response": {

--- a/src/test/resources/wiremock/mappings/mapping-historicalPrices.json
+++ b/src/test/resources/wiremock/mappings/mapping-historicalPrices.json
@@ -1,42 +1,218 @@
 {
-  "id" : "16369e06-78d4-40a7-98d1-3dbe0ba82fc9",
-  "name" : "historical_prices",
-  "request" : {
-    "url" : "/stock/AAPL/chart/5d",
-    "method" : "GET"
-  },
-  "response" : {
-    "status" : 200,
-    "jsonBody" : [
-      {
-        "close":116.59,
-        "high":117.49,
-        "low":116.22,
-        "open":116.57,
-        "symbol":"AAPL",
-        "volume":46691331,
-        "date":"2020-01-26"
-      }
-    ],
-    "headers" : {
-      "Server" : "nginx",
-      "Date" : "Thu, 08 Aug 2019 14:08:53 GMT",
-      "Content-Type" : "application/json; charset=utf-8",
-      "Connection" : "keep-alive",
-      "set-cookie" : "ctoken=958c0e17a3f542a2a13ef676b670326d; Domain=.iextrading.com; Path=/; Expires=Fri, 09 Aug 2019 02:08:53 GMT; Secure",
-      "Content-Security-Policy" : "default-src 'self'; child-src 'none'; object-src 'none'; style-src 'self' 'unsafe-inline'; font-src data:; frame-src 'self'; connect-src 'self' https://auth.iextrading.com https://api.iextrading.com https://api.iextrading.com wss://iextrading.com wss://tops.iextrading.com wss://api.iextrading.com wss://iextrading.com https://iextrading.com/member-center; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google-analytics.com/analytics.js;",
-      "X-Content-Security-Policy" : "default-src 'self'; child-src 'none'; object-src 'none'; style-src 'self' 'unsafe-inline'; font-src data:; frame-src 'self'; connect-src 'self' https://auth.iextrading.com https://api.iextrading.com https://api.iextrading.com wss://iextrading.com wss://tops.iextrading.com wss://api.iextrading.com wss://iextrading.com https://iextrading.com/member-center; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google-analytics.com/analytics.js;",
-      "Frame-Options" : "SAMEORIGIN",
-      "X-Frame-Options" : "SAMEORIGIN",
-      "X-Content-Type-Options" : "nosniff",
-      "Strict-Transport-Security" : "max-age=15768000",
-      "Access-Control-Allow-Origin" : "*",
-      "Access-Control-Allow-Credentials" : "true",
-      "Access-Control-Allow-Methods" : "GET, OPTIONS",
-      "Access-Control-Allow-Headers" : "Origin, X-Requested-With, Content-Type, Accept"
+  "mappings": [
+    {
+      "id": "16369e06-78d4-40a7-98d1-3dbe0ba82fc9",
+      "name": "historical_prices",
+      "request": {
+        "url": "/stock/AAPL/chart/5d?token=DUMMY_TKN",
+        "method": "GET"
+      },
+      "response": {
+        "status": 200,
+        "jsonBody": [
+          {
+            "close": 166.23,
+            "high": 168.91,
+            "low": 165.55,
+            "open": 168.47,
+            "symbol": "AAPL",
+            "volume": 76678441,
+            "date": "2022-03-03"
+          },
+          {
+            "close": 163.17,
+            "high": 165.55,
+            "low": 162.1,
+            "open": 164.49,
+            "symbol": "AAPL",
+            "volume": 83819592,
+            "date": "2022-03-04"
+          },
+          {
+            "close": 159.3,
+            "high": 165.02,
+            "low": 159.04,
+            "open": 163.36,
+            "symbol": "AAPL",
+            "volume": 96418845,
+            "date": "2022-03-07"
+          }
+        ],
+        "headers": {
+          "Server": "nginx",
+          "Date": "Thu, 08 Aug 2019 14:08:53 GMT",
+          "Content-Type": "application/json; charset=utf-8",
+          "Connection": "keep-alive",
+          "set-cookie": "ctoken=958c0e17a3f542a2a13ef676b670326d; Domain=.iextrading.com; Path=/; Expires=Fri, 09 Aug 2019 02:08:53 GMT; Secure",
+          "Content-Security-Policy": "default-src 'self'; child-src 'none'; object-src 'none'; style-src 'self' 'unsafe-inline'; font-src data:; frame-src 'self'; connect-src 'self' https://auth.iextrading.com https://api.iextrading.com https://api.iextrading.com wss://iextrading.com wss://tops.iextrading.com wss://api.iextrading.com wss://iextrading.com https://iextrading.com/member-center; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google-analytics.com/analytics.js;",
+          "X-Content-Security-Policy": "default-src 'self'; child-src 'none'; object-src 'none'; style-src 'self' 'unsafe-inline'; font-src data:; frame-src 'self'; connect-src 'self' https://auth.iextrading.com https://api.iextrading.com https://api.iextrading.com wss://iextrading.com wss://tops.iextrading.com wss://api.iextrading.com wss://iextrading.com https://iextrading.com/member-center; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google-analytics.com/analytics.js;",
+          "Frame-Options": "SAMEORIGIN",
+          "X-Frame-Options": "SAMEORIGIN",
+          "X-Content-Type-Options": "nosniff",
+          "Strict-Transport-Security": "max-age=15768000",
+          "Access-Control-Allow-Origin": "*",
+          "Access-Control-Allow-Credentials": "true",
+          "Access-Control-Allow-Methods": "GET, OPTIONS",
+          "Access-Control-Allow-Headers": "Origin, X-Requested-With, Content-Type, Accept"
+        }
+      },
+      "uuid": "16369e06-78d4-40a7-98d1-3dbe0ba82fc9",
+      "persistent": true,
+      "insertionIndex": 5
+    },
+    {
+      "id": "16369e06-78d4-40a7-98d1-3dbe0ba82fc9",
+      "name": "historical_prices_date",
+      "request": {
+        "url": "/stock/twtr/chart/date/20200220?token=DUMMY_TKN",
+        "method": "GET"
+      },
+      "response": {
+        "status": 200,
+        "jsonBody": [
+          {
+            "close": 38.785,
+            "high": 38.785,
+            "low": 38.785,
+            "open": 38.785,
+            "symbol": null,
+            "volume": 100,
+            "date": "2020-02-20"
+          },
+          {
+            "close": 38.775,
+            "high": 38.775,
+            "low": 38.775,
+            "open": 38.775,
+            "symbol": null,
+            "volume": 15,
+            "date": "2020-02-20"
+          },
+          {
+            "close": null,
+            "high": null,
+            "low": null,
+            "open": null,
+            "symbol": null,
+            "volume": 0,
+            "date": "2020-02-20"
+          },
+          {
+            "close": 38.58,
+            "high": 38.66,
+            "low": 38.51,
+            "open": 38.66,
+            "symbol": null,
+            "volume": 1947,
+            "date": "2020-02-20"
+          },
+          {
+            "close": 38.63,
+            "high": 38.67,
+            "low": 38.63,
+            "open": 38.67,
+            "symbol": null,
+            "volume": 200,
+            "date": "2020-02-20"
+          },
+          {
+            "close": null,
+            "high": null,
+            "low": null,
+            "open": null,
+            "symbol": null,
+            "volume": 0,
+            "date": "2020-02-20"
+          },
+          {
+            "close": 38.645,
+            "high": 38.645,
+            "low": 38.6,
+            "open": 38.61,
+            "symbol": null,
+            "volume": 1056,
+            "date": "2020-02-20"
+          },
+          {
+            "close": 38.7,
+            "high": 38.7,
+            "low": 38.65,
+            "open": 38.65,
+            "symbol": null,
+            "volume": 172,
+            "date": "2020-02-20"
+          },
+          {
+            "close": 38.545,
+            "high": 38.65,
+            "low": 38.545,
+            "open": 38.65,
+            "symbol": null,
+            "volume": 290,
+            "date": "2020-02-20"
+          },
+          {
+            "close": 38.56,
+            "high": 38.56,
+            "low": 38.485,
+            "open": 38.535,
+            "symbol": null,
+            "volume": 400,
+            "date": "2020-02-20"
+          }
+        ],
+        "headers": {
+          "Server": "nginx",
+          "Date": "Thu, 08 Aug 2019 14:08:53 GMT",
+          "Content-Type": "application/json; charset=utf-8",
+          "Connection": "keep-alive",
+          "set-cookie": "ctoken=958c0e17a3f542a2a13ef676b670326d; Domain=.iextrading.com; Path=/; Expires=Fri, 09 Aug 2019 02:08:53 GMT; Secure",
+          "Content-Security-Policy": "default-src 'self'; child-src 'none'; object-src 'none'; style-src 'self' 'unsafe-inline'; font-src data:; frame-src 'self'; connect-src 'self' https://auth.iextrading.com https://api.iextrading.com https://api.iextrading.com wss://iextrading.com wss://tops.iextrading.com wss://api.iextrading.com wss://iextrading.com https://iextrading.com/member-center; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google-analytics.com/analytics.js;",
+          "X-Content-Security-Policy": "default-src 'self'; child-src 'none'; object-src 'none'; style-src 'self' 'unsafe-inline'; font-src data:; frame-src 'self'; connect-src 'self' https://auth.iextrading.com https://api.iextrading.com https://api.iextrading.com wss://iextrading.com wss://tops.iextrading.com wss://api.iextrading.com wss://iextrading.com https://iextrading.com/member-center; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google-analytics.com/analytics.js;",
+          "Frame-Options": "SAMEORIGIN",
+          "X-Frame-Options": "SAMEORIGIN",
+          "X-Content-Type-Options": "nosniff",
+          "Strict-Transport-Security": "max-age=15768000",
+          "Access-Control-Allow-Origin": "*",
+          "Access-Control-Allow-Credentials": "true",
+          "Access-Control-Allow-Methods": "GET, OPTIONS",
+          "Access-Control-Allow-Headers": "Origin, X-Requested-With, Content-Type, Accept"
+        }
+      },
+      "uuid": "16369e06-78d4-40a7-98d1-3dbe0ba82fc9",
+      "persistent": true,
+      "insertionIndex": 5
+    },
+    {
+      "id": "16369e06-78d4-40a7-98d1-3dbe0ba82fc9",
+      "name": "historical_prices_no_range",
+      "request": {
+        "url": "/stock/twtr/chart?token=DUMMY_TKN",
+        "method": "GET"
+      },
+      "response": {
+        "status": 500,
+        "headers": {
+          "Server": "nginx",
+          "Date": "Thu, 08 Aug 2019 14:08:53 GMT",
+          "Content-Type": "application/json; charset=utf-8",
+          "Connection": "keep-alive",
+          "set-cookie": "ctoken=958c0e17a3f542a2a13ef676b670326d; Domain=.iextrading.com; Path=/; Expires=Fri, 09 Aug 2019 02:08:53 GMT; Secure",
+          "Content-Security-Policy": "default-src 'self'; child-src 'none'; object-src 'none'; style-src 'self' 'unsafe-inline'; font-src data:; frame-src 'self'; connect-src 'self' https://auth.iextrading.com https://api.iextrading.com https://api.iextrading.com wss://iextrading.com wss://tops.iextrading.com wss://api.iextrading.com wss://iextrading.com https://iextrading.com/member-center; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google-analytics.com/analytics.js;",
+          "X-Content-Security-Policy": "default-src 'self'; child-src 'none'; object-src 'none'; style-src 'self' 'unsafe-inline'; font-src data:; frame-src 'self'; connect-src 'self' https://auth.iextrading.com https://api.iextrading.com https://api.iextrading.com wss://iextrading.com wss://tops.iextrading.com wss://api.iextrading.com wss://iextrading.com https://iextrading.com/member-center; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google-analytics.com/analytics.js;",
+          "Frame-Options": "SAMEORIGIN",
+          "X-Frame-Options": "SAMEORIGIN",
+          "X-Content-Type-Options": "nosniff",
+          "Strict-Transport-Security": "max-age=15768000",
+          "Access-Control-Allow-Origin": "*",
+          "Access-Control-Allow-Credentials": "true",
+          "Access-Control-Allow-Methods": "GET, OPTIONS",
+          "Access-Control-Allow-Headers": "Origin, X-Requested-With, Content-Type, Accept"
+        }
+      },
+      "uuid": "16369e06-78d4-40a7-98d1-3dbe0ba82fc9",
+      "persistent": true,
+      "insertionIndex": 5
     }
-  },
-  "uuid" : "16369e06-78d4-40a7-98d1-3dbe0ba82fc9",
-  "persistent" : true,
-  "insertionIndex" : 5
+  ]
 }

--- a/src/test/resources/wiremock/mappings/mapping-historicalPrices.json
+++ b/src/test/resources/wiremock/mappings/mapping-historicalPrices.json
@@ -1,0 +1,42 @@
+{
+  "id" : "16369e06-78d4-40a7-98d1-3dbe0ba82fc9",
+  "name" : "historical_prices",
+  "request" : {
+    "url" : "/stock/aapl/chart/5d",
+    "method" : "GET"
+  },
+  "response" : {
+    "status" : 200,
+    "jsonBody" : [
+      {
+        "close":116.59,
+        "high":117.49,
+        "low":116.22,
+        "open":116.57,
+        "symbol":"AAPL",
+        "volume":46691331,
+        "date":"2020-01-26",
+      }
+    ],
+    "headers" : {
+      "Server" : "nginx",
+      "Date" : "Thu, 08 Aug 2019 14:08:53 GMT",
+      "Content-Type" : "application/json; charset=utf-8",
+      "Connection" : "keep-alive",
+      "set-cookie" : "ctoken=958c0e17a3f542a2a13ef676b670326d; Domain=.iextrading.com; Path=/; Expires=Fri, 09 Aug 2019 02:08:53 GMT; Secure",
+      "Content-Security-Policy" : "default-src 'self'; child-src 'none'; object-src 'none'; style-src 'self' 'unsafe-inline'; font-src data:; frame-src 'self'; connect-src 'self' https://auth.iextrading.com https://api.iextrading.com https://api.iextrading.com wss://iextrading.com wss://tops.iextrading.com wss://api.iextrading.com wss://iextrading.com https://iextrading.com/member-center; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google-analytics.com/analytics.js;",
+      "X-Content-Security-Policy" : "default-src 'self'; child-src 'none'; object-src 'none'; style-src 'self' 'unsafe-inline'; font-src data:; frame-src 'self'; connect-src 'self' https://auth.iextrading.com https://api.iextrading.com https://api.iextrading.com wss://iextrading.com wss://tops.iextrading.com wss://api.iextrading.com wss://iextrading.com https://iextrading.com/member-center; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google-analytics.com/analytics.js;",
+      "Frame-Options" : "SAMEORIGIN",
+      "X-Frame-Options" : "SAMEORIGIN",
+      "X-Content-Type-Options" : "nosniff",
+      "Strict-Transport-Security" : "max-age=15768000",
+      "Access-Control-Allow-Origin" : "*",
+      "Access-Control-Allow-Credentials" : "true",
+      "Access-Control-Allow-Methods" : "GET, OPTIONS",
+      "Access-Control-Allow-Headers" : "Origin, X-Requested-With, Content-Type, Accept"
+    }
+  },
+  "uuid" : "16369e06-78d4-40a7-98d1-3dbe0ba82fc9",
+  "persistent" : true,
+  "insertionIndex" : 5
+}

--- a/src/test/resources/wiremock/mappings/mapping-lastTradedPrice.json
+++ b/src/test/resources/wiremock/mappings/mapping-lastTradedPrice.json
@@ -2,6 +2,7 @@
   "id" : "16369e06-78d4-40a7-98d1-3dbe0ba82fc9",
   "name" : "tops_last",
   "request" : {
+
     "url" : "/tops/last?symbols=FB",
     "method" : "GET"
   },

--- a/src/test/resources/wiremock/mappings/mapping-lastTradedPrice.json
+++ b/src/test/resources/wiremock/mappings/mapping-lastTradedPrice.json
@@ -3,7 +3,7 @@
   "name" : "tops_last",
   "request" : {
 
-    "url" : "/tops/last?symbols=FB",
+    "url" : "/tops/last?token=DUMMY_TKN&symbols=FB",
     "method" : "GET"
   },
   "response" : {

--- a/src/test/resources/wiremock/mappings/mapping-symbols.json
+++ b/src/test/resources/wiremock/mappings/mapping-symbols.json
@@ -2,7 +2,7 @@
   "id": "4dc720df-b9cd-465e-a27e-68ccdb49ef31",
   "name": "ref-data_symbols",
   "request": {
-    "url": "/ref-data/symbols",
+    "url": "/ref-data/symbols?token=DUMMY_TKN",
     "method": "GET"
   },
   "response": {


### PR DESCRIPTION
The historical prices endpoint is working for the most part (see screenshot below). The only thing I'm stuck on is that the [Iex API historical prices endpoint](https://iexcloud.io/docs/api/#historical-prices) allows for an optional "date" path variable: GET /stock/{symbol}/chart/{range}/**{date}**.  For example, /stock/twtr/chart/5d vs. /stock/twtr/chart/date/**20190220**. I tried to add an optional path variable in the IexClient class as follows:

```
@GetMapping(value = {"/stock/{symbol}/chart/{range}", "/stock/{symbol}/chart/{date}"})
  List<IexHistoricalPrice> getHistoricalPrices(@PathVariable("symbol") String symbol,
      @PathVariable("range") String range, @PathVariable(value = "date", required = false) String date);
```

However, I keep getting this error: **Method getHistoricalPrices can only contain at most 1 value field**. After doing some research, it seems that optional parameters may not be supported by Feign. For example, [this stackoverflow post](https://stackoverflow.com/questions/59413035/feign-client-support-for-optional-request-param). I tried some other workarounds (like method overloading), but I couldn't get it to go. Perhaps I've implemented IexRestController and IexService incorrectly?

For the purposes of this exercise, should I keep trying to figure out how to implement that optional "date" @PathVariable or should I move onto Issue #3? And if so, do you have any tips on including the optional @PathVariable? 


![Issue 2 Tests](https://user-images.githubusercontent.com/92825615/157105865-8c2260b9-a369-4787-92b9-097c6e1df106.JPG)
